### PR TITLE
Kneipen erweitern

### DIFF
--- a/in-der-stadt/kneipen.tex
+++ b/in-der-stadt/kneipen.tex
@@ -29,7 +29,7 @@ Preis: $\star$ teuer, $\star\ \star$ noch teurer, $\star\ \star\ \star$ extrem t
 
     \place{Karls}{Lauerstraße 7-9}{Kneipe mit Billardtisch und Dartscheibe. Gut um sich voll\/laufen zu lassen oder einfach nur zu versacken.}{$\star\ \star$}
 
-    \place{Karlstorbahnhof}{Am Karlstor\,/\,S-Bahnhof Altstadt}{Richtig gute Diskothek (Nicht nur; im Gebäude gibts auch Theater, Lesungen ect. - viel Kultur) mit sehr variabler Musik. Was zum tanzen und weniger zum trinken, denn die Preise können sich meistens sehen lassen, genauso der Eintritt}{$\star\ \star\ \star$}
+    \place{Karlstorbahnhof}{Am Karlstor\,/\,S-Bahnhof Altstadt}{Richtig gute Diskothek (Nicht nur; im Gebäude gibts auch Theater, Lesungen etc. -- viel Kultur) mit sehr variabler Musik. Was zum tanzen und weniger zum trinken, denn die Preise können sich meistens sehen lassen, genauso der Eintritt}{$\star\ \star\ \star$}
 
     \place{Marstall}{Marstallhof}{Keine typische Kneipe, vielmehr Mensa mit Bier. Trotzdem gut geeignet sich zu treffen, zum Vorglühen und entscheiden, wo die weitere Party ihren Anfang nehmen soll.}{$\star$}
 
@@ -55,6 +55,8 @@ Preis: $\star$ teuer, $\star\ \star$ noch teurer, $\star\ \star\ \star$ extrem t
 
     \place{Vater Rhein}{Untere Neckarstraße 20}{Legendär für seine \EUR{1,90}-Spaghetti bis halb drei. Hier lässt sich der Abend gemütlich ausklingen.}{$\star$}
 
+	\place{Vetters}{Steingasse 9}{Nicht zum Bleiben, aber für die Maß to go. Gibts da für \EUR{3}, schmeckt hervorragend. Ansonsten gutbürgerliche Küche und älteres Klientel}{$\star\ \star$}
+
 \end{description}
 
 % trim=l b r t
@@ -67,6 +69,8 @@ Preis: $\star$ teuer, $\star\ \star$ noch teurer, $\star\ \star\ \star$ extrem t
 
     \place{Bar 133}{Wohnheim \gls{INF} 133}{Wohnheimsbar, eigentlich nur für Bewohner der 1xx Wohnheime. Mittwochs und sonntags geöffnet mit gutem Angebot, günstigen Cocktails und Tischkicker. Immer wieder für einen Absturz gut.}{$\star$}
 
+	\place{Comabar}{Comenius-Haus}{Bar des Comenius-Hauses direkt am Bunsengymnasium. Dienstags und Donnerstags geöffnet, super Team, günstige Cocktails, Kicker und Tischtennisplatte vorhanden. Definitiv empfehlenswert.}{$\star$}
+
 %    \place{Breidenbach Studios}{Hebelstraße 18}{Absoluter Hipster-Laden: Ehemalige Gasflaschenhandlung, die zu einem Künstlerhaus und Coworking-Space umgebaut wurde. Hier finden immer wieder großartige Partys statt.}{$\star\ \star\ \star$}
 
     \place{Cappuchino}{Bergheimer Straße 8}{Hippe Mischung von Kaffeehaus mit lautem Elektro.}{$\star\ \star$}
@@ -78,9 +82,7 @@ ofs.}{$\star\ \star$}
 
     \place{O'Reilly's}{Brückenkopfstraße 1}{Irish Pub mit Karaoke.}{$\star\ \star\ \star$}
 
-    \place{schwimmbad club}{INF, am Tiergartenschwimmbad}{Hier läuft echt alles. Ob House, Latin, 80s oder Rock, es findet sich immer das passende Event, das mit \EUR{4}\,–\,\EUR{8} Eintritt auch halbwegs bezahlbar ist. Besonderes Sternchen ist das Schwarze Schwimmbad jeden 4. Samstag im Monat.}{$\star\ \star$}
-
-    \place{P11}{Am Römerkreis}{Nettes Café, dass Abends bis etwa eins Barbetrieb hat. Geile Tapete!}{$\star\ \star$}
+    \place{P11}{Am Römerkreis}{Nettes Café, dass Abends bis etwa eins Barbetrieb hat. Trotz der Nähe zum Römerkreis angenehme Atmosphäre. Geile Tapete!}{$\star\ \star$}
 
     \place{Villa Nachttanz}{Im Klingenbühl 6}{Alternativer Kulturverein -- rechnet mit allem außer Mainstream. Sehr günstig, mit Lagerfeuer im Garten. Lohnt sich jedes mal.}{$\star$}
 


### PR DESCRIPTION
Den Schwimmbad-Club gibt es nicht mehr. Das Vetters ist für sein Bier to
go auf jeden Fall empfehlenswert, die Coma-Bar auch.