### PR TITLE
Für Erstsemester irrelevante Informatiklehrbücher auskommentiert.

### DIFF
--- a/wie-geht-studium/lehrbuecher.tex
+++ b/wie-geht-studium/lehrbuecher.tex
@@ -108,15 +108,16 @@ In den Informatik-Vorlesungen wird allgemein bewusst sehr wenig Literatur verwen
 
 \end{description}
 
-\subsubsection{Algorithmen und Datenstrukturen}
-\begin{description}[style=unboxed]
-%Ist dieses Buch wirklich relevant?
-\item[Sedgewick: Algorithms]{
-	ist eine sehr einsteigerfreundliche Lektüre, in der verschiedene Algorithmen eingeführt und anhand einer Java-Implementation näher erläutert werden. Auf die eigene Implementation verschiedener Datenstrukturen wird hier leider nicht eingegangen, sondern es wird auf die in den Bibliotheksfunktionen bereits vorhandenen Strukturen zurückgegriffen. Die Programmbeispiele in Java sind sehr simpel gehalten und lassen sich somit relativ einfach in C++ oder in Python umformulieren. Dieses Buch kann vorweg als Begleitlektüre für die Vorlesung Praktische Informatik genommen werden und aufgrund der Java-Beispiele bereitet es die Leserin ebenfalls auf die Vorlesung Einführung in Software Engineering vor.} 
+% Es werden nur noch Bücher für Erstsemestervorlesungen empfohlen, da wie im Allgemeinen Informatik Teil erläutert, ohnehin mehr Folien und online Materialien verwendet werden als Lehrbücher.
+% \subsubsection{Algorithmen und Datenstrukturen}
+% \begin{description}[style=unboxed]
 
-\item[Cormen: Algorithms]{
-	ist sozusagen die Algorithmen-Bibel. Jede Art von Sortier-, Textbearbeitungs-, Graphen- und Hashing-Algorithmus wird hier in Pseudocode und mit bildlich dargestellten Beispielen näher erklärt und mathematisch auf ihre Korrektheit geprüft. Es ist nicht nur eine sehr einsteigerfreundliche Lektüre sondern auch ein Nachschlagewerk für erfahrene Mathematikerinnen und Informatikerinnen.}
-\end{description}
+% \item[Sedgewick: Algorithms]{
+% 	ist eine sehr einsteigerfreundliche Lektüre, in der verschiedene Algorithmen eingeführt und anhand einer Java-Implementation näher erläutert werden. Auf die eigene Implementation verschiedener Datenstrukturen wird hier leider nicht eingegangen, sondern es wird auf die in den Bibliotheksfunktionen bereits vorhandenen Strukturen zurückgegriffen. Die Programmbeispiele in Java sind sehr simpel gehalten und lassen sich somit relativ einfach in C++ oder in Python umformulieren. Dieses Buch kann vorweg als Begleitlektüre für die Vorlesung Praktische Informatik genommen werden und aufgrund der Java-Beispiele bereitet es die Leserin ebenfalls auf die Vorlesung Einführung in Software Engineering vor.} 
+
+% \item[Cormen: Algorithms]{
+% 	ist sozusagen die Algorithmen-Bibel. Jede Art von Sortier-, Textbearbeitungs-, Graphen- und Hashing-Algorithmus wird hier in Pseudocode und mit bildlich dargestellten Beispielen näher erklärt und mathematisch auf ihre Korrektheit geprüft. Es ist nicht nur eine sehr einsteigerfreundliche Lektüre sondern auch ein Nachschlagewerk für erfahrene Mathematikerinnen und Informatikerinnen.}
+% \end{description}
 
 \subsubsection{Technische Informatik}
 \begin{description}[style=unboxed]
@@ -124,39 +125,40 @@ In den Informatik-Vorlesungen wird allgemein bewusst sehr wenig Literatur verwen
 	ist ein übersichtlich gegliedertes Buch, welches die Vorlesungsinhalte im Großen und Ganzen abdeckt. Insbesondere wird auf die boolesche Algebra, unterschiedliche Schaltwerke, Rechnen in anderen Zahlensystemen und auf die Computerarchitektur eingegangen.}
 \end{description}
 
-\subsubsection{Betriebssysteme \& Netzwerke}
-\begin{description}[style=unboxed]
-\item[Silberschatz: Operating Systems Concepts]{
-	ist ein auffälliges Buch mit Dinosaurier auf dem Buchcover und enthält die ersten zwei Drittel der Vorlesung, und zwar den Betriebssystemeteil. Im Großen und Ganzen werden hier der Umgang mit Prozessen in einem Betriebssystem und die verschiedenen Dateisysteme erklärt. Die zuvor erklärte Theorie wird dann an realen Betriebssystemen wie Windows oder Linux dargestellt.}
+% Es werden nur noch Bücher für Erstsemestervorlesungen empfohlen, da wie im Allgemeinen Informatik Teil erläutert, ohnehin mehr Folien und online Materialien verwendet werden als Lehrbücher.
+% \subsubsection{Betriebssysteme \& Netzwerke}
+% \begin{description}[style=unboxed]
+% \item[Silberschatz: Operating Systems Concepts]{
+% 	ist ein auffälliges Buch mit Dinosaurier auf dem Buchcover und enthält die ersten zwei Drittel der Vorlesung, und zwar den Betriebssystemeteil. Im Großen und Ganzen werden hier der Umgang mit Prozessen in einem Betriebssystem und die verschiedenen Dateisysteme erklärt. Die zuvor erklärte Theorie wird dann an realen Betriebssystemen wie Windows oder Linux dargestellt.}
 
-\item[Tanenbaum: Computer Networks]{
-	ist ebenfalls ein Buch mit einem extravaganten Cover und deckt das letzte Drittel - den Netzwerketeil - der Vorlesung ab. Das Buch ist nach den Schichten der Internetprotokollfamilie unterteilt. Hier werden, wenn auch sehr textlastig, die verschiedene Techniken des Internets erklärt. Leider werden wichtige Algorithmen, die am Ende der Vorlesung drankommen, nur kurz oder gar nicht erwähnt.}
-\end{description}
+% \item[Tanenbaum: Computer Networks]{
+% 	ist ebenfalls ein Buch mit einem extravaganten Cover und deckt das letzte Drittel - den Netzwerketeil - der Vorlesung ab. Das Buch ist nach den Schichten der Internetprotokollfamilie unterteilt. Hier werden, wenn auch sehr textlastig, die verschiedene Techniken des Internets erklärt. Leider werden wichtige Algorithmen, die am Ende der Vorlesung drankommen, nur kurz oder gar nicht erwähnt.}
+% \end{description}
 
-\subsubsection{Datenbanken}
-\begin{description}
-\item[Kemper: Datenbanksysteme]{
-	ist eines der wenigen deutschsprachigen Bücher, die in der Informatiklehre relevant sind. Obwohl dieses Buch relativ dick ist, ist der Inhalt verständlich und kompakt beschrieben. Die typischen Themen wie das Entity-Relationship-Modell, SQL, B-Bäume und Anfrageoptimierung werden im vollen Umfang abgedeckt. Für fleißige Menschen gibt es auch ein Übungsbuch dazu.}
-\end{description}
+% \subsubsection{Datenbanken}
+% \begin{description}
+% \item[Kemper: Datenbanksysteme]{
+% 	ist eines der wenigen deutschsprachigen Bücher, die in der Informatiklehre relevant sind. Obwohl dieses Buch relativ dick ist, ist der Inhalt verständlich und kompakt beschrieben. Die typischen Themen wie das Entity-Relationship-Modell, SQL, B-Bäume und Anfrageoptimierung werden im vollen Umfang abgedeckt. Für fleißige Menschen gibt es auch ein Übungsbuch dazu.}
+% \end{description}
 
-\subsubsection{Theoretische Informatik}
-\begin{description}[style=unboxed]
+% \subsubsection{Theoretische Informatik}
+% \begin{description}[style=unboxed]
 
-%Ist das Buch noch relevant?
-\item[Vossen, Witt: Grundkurs Theoretische Informatik]{
-	enthält jedes Thema, das in der Vorlesung Theoretische Informatik behandelt wird, außer die Registermaschine. Hier sollte man jedoch etwas aufpassen, denn die ersten zwei Drittel der Vorlesung (Berechenbarkeit und Komplexität) werden erst ab dem achten Kapitel des Buches beschrieben, und das letzte Drittel der Vorlesung (Formale Sprachen und Automatentheorie) wird ab dem ersten Kapitel des Buches beschrieben. Hier werden zwar, ähnlich wie in einer Mathevorlesung, die Themen relativ knapp und beweislastig beschrieben, aber regelmäßig mit Rechenbeispielen näher erläutert. Jedoch unterscheiden sich leider die Notationen von denen aus der Vorlesung.}
+% %Ist das Buch noch relevant?
+% \item[Vossen, Witt: Grundkurs Theoretische Informatik]{
+% 	enthält jedes Thema, das in der Vorlesung Theoretische Informatik behandelt wird, außer die Registermaschine. Hier sollte man jedoch etwas aufpassen, denn die ersten zwei Drittel der Vorlesung (Berechenbarkeit und Komplexität) werden erst ab dem achten Kapitel des Buches beschrieben, und das letzte Drittel der Vorlesung (Formale Sprachen und Automatentheorie) wird ab dem ersten Kapitel des Buches beschrieben. Hier werden zwar, ähnlich wie in einer Mathevorlesung, die Themen relativ knapp und beweislastig beschrieben, aber regelmäßig mit Rechenbeispielen näher erläutert. Jedoch unterscheiden sich leider die Notationen von denen aus der Vorlesung.}
 
-\item[Cohen: Introduction to Computer Theory]{ 
-	ist ein Buch, was nicht nur die Theoretische Informatik abdeckt, sondern auch die nachfolgenden Vorlesungen, wie Formale Sprachen \& Automatentheorie und Berechenbarkeit \& Komplexität. Dieses Buch zeichnet sich auch durch viele Beweis- und Rechenbeispiele aus und ist auch nota\-tionsmäßig sehr nahe an der Vorlesung.}
-\end{description}
+% \item[Cohen: Introduction to Computer Theory]{ 
+% 	ist ein Buch, was nicht nur die Theoretische Informatik abdeckt, sondern auch die nachfolgenden Vorlesungen, wie Formale Sprachen \& Automatentheorie und Berechenbarkeit \& Komplexität. Dieses Buch zeichnet sich auch durch viele Beweis- und Rechenbeispiele aus und ist auch nota\-tionsmäßig sehr nahe an der Vorlesung.}
+% \end{description}
 
-\subsubsection{Software-Engineering}
-\begin{description}[style=unboxed]
+% \subsubsection{Software-Engineering}
+% \begin{description}[style=unboxed]
 
-%Ist das Buch relevant, wichtiger wäre vielleicht das Buch von Ludewig & Lichter?
-\item[Sommerville: Software Engineering]{
-	ist ein sehr text-, tabellen- und diagrammlastiges Buch, was aber auch typisch für Software Engineering ist. Es deckt nicht komplett den Stoff der Vorlesung Software Engineering ab, aber schneidet fast jedes Thema zu einem guten Teil an. Dabei werden wie in der Vorlesung verschiedene ähnlich klingende Begriffe definiert, aber dafür klar auseinander gehalten, verschiedene UML-Diagrammtypen vorgestellt, das Testen von Software erläutert, Modelle zur Planung eines Software-Projektes beschrieben und der Umgang mit einer Kundin erklärt.}
-\end{description}
+% %Ist das Buch relevant, wichtiger wäre vielleicht das Buch von Ludewig & Lichter?
+% \item[Sommerville: Software Engineering]{
+% 	ist ein sehr text-, tabellen- und diagrammlastiges Buch, was aber auch typisch für Software Engineering ist. Es deckt nicht komplett den Stoff der Vorlesung Software Engineering ab, aber schneidet fast jedes Thema zu einem guten Teil an. Dabei werden wie in der Vorlesung verschiedene ähnlich klingende Begriffe definiert, aber dafür klar auseinander gehalten, verschiedene UML-Diagrammtypen vorgestellt, das Testen von Software erläutert, Modelle zur Planung eines Software-Projektes beschrieben und der Umgang mit einer Kundin erklärt.}
+% \end{description}
 
 \subsubsection{Nachschlagewerke}
 


### PR DESCRIPTION
Behebt #318. Es werden jetzt nur noch Lehrbücher für Informatikvorlesungen des ersten Semesters empfohlen. Die anderen Literaturempfehlungen sind auskommentiert, sodass sie später wieder hinzugefügt werden können, falls gewünscht.