### PR TITLE
remove link to mathphystheo.de

### DIFF
--- a/mantelbogen.tex
+++ b/mantelbogen.tex
@@ -80,7 +80,7 @@
   \end{textblock*}
 }{
   \begin{textblock*}{210.5mm}[0,0](-.25mm,-.6mm)
-    \href{http://mathphystheo.de}{\includegraphics[width=210.5mm]{\festimage}} % exkl. bleed
+    \includegraphics[width=210.5mm]{\festimage} % exkl. bleed
   \end{textblock*}
 }
 


### PR DESCRIPTION
Aufgrund von Corona wird es dieses Jahr keine MathPhysTheo geben.